### PR TITLE
Basic MIR pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target
 *.dot
 log
 sysroot/
+
+
+*.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "flux-macros",
  "flux-metadata",
  "flux-middle",
+ "flux-opt",
  "flux-refineck",
  "flux-rustc-bridge",
  "flux-syntax",
@@ -636,6 +637,15 @@ dependencies = [
  "serde_json",
  "toposort-scc",
  "tracing",
+]
+
+[[package]]
+name = "flux-opt"
+version = "0.1.0"
+dependencies = [
+ "flux-config",
+ "flux-macros",
+ "flux-middle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ flux-infer = { path = "./crates/flux-infer", version = "0.1.0" }
 flux-macros = { path = "./crates/flux-macros", version = "0.1.0" }
 flux-metadata = { path = "./crates/flux-metadata", version = "0.1.0" }
 flux-middle = { path = "./crates/flux-middle", version = "0.1.0" }
+flux-opt = { path = "./crates/flux-opt", version = "0.1.0" }
 flux-refineck = { path = "./crates/flux-refineck", version = "0.1.0" }
 flux-rustc-bridge = { path = "./crates/flux-rustc-bridge", version = "0.1.0" }
 flux-syntax = { path = "./crates/flux-syntax", version = "0.1.0" }

--- a/crates/flux-driver/Cargo.toml
+++ b/crates/flux-driver/Cargo.toml
@@ -20,6 +20,7 @@ flux-fhir-analysis.workspace = true
 flux-macros.workspace = true
 flux-metadata.workspace = true
 flux-middle.workspace = true
+flux-opt.workspace = true
 flux-refineck.workspace = true
 flux-rustc-bridge.workspace = true
 flux-syntax.workspace = true

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -16,7 +16,7 @@ use flux_middle::{
     queries::{Providers, QueryResult},
     timings,
 };
-use flux_opt::{self as flux_opt, run_mir_analysis_on_all_functions};
+use flux_opt::{self as flux_opt, gather_crate_panics};
 use flux_refineck as refineck;
 use itertools::Itertools;
 use rustc_borrowck::consumers::ConsumerOptions;
@@ -80,7 +80,7 @@ impl FluxCallbacks {
                 encode_and_save_metadata(genv);
             }
 
-            run_mir_analysis_on_all_functions(genv);
+            gather_crate_panics(genv);
         });
 
         sess.finish_diagnostics();

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -80,7 +80,7 @@ impl FluxCallbacks {
                 encode_and_save_metadata(genv);
             }
 
-            gather_crate_panics(tcx);
+            gather_crate_panics(tcx).unwrap();
         });
 
         sess.finish_diagnostics();

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -16,7 +16,7 @@ use flux_middle::{
     queries::{Providers, QueryResult},
     timings,
 };
-use flux_opt::{self as flux_opt, entry_point, run_mir_analysis_on_all_functions};
+use flux_opt::{self as flux_opt, run_mir_analysis_on_all_functions};
 use flux_refineck as refineck;
 use itertools::Itertools;
 use rustc_borrowck::consumers::ConsumerOptions;

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -16,6 +16,7 @@ use flux_middle::{
     queries::{Providers, QueryResult},
     timings,
 };
+use flux_opt as flux_opt;
 use flux_refineck as refineck;
 use itertools::Itertools;
 use rustc_borrowck::consumers::ConsumerOptions;
@@ -80,6 +81,9 @@ impl FluxCallbacks {
             }
         });
         sess.finish_diagnostics();
+
+        // Call flux_opt entry point
+        flux_opt::entry_point();
     }
 }
 

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -80,7 +80,7 @@ impl FluxCallbacks {
                 encode_and_save_metadata(genv);
             }
 
-            gather_crate_panics(genv);
+            gather_crate_panics(tcx);
         });
 
         sess.finish_diagnostics();

--- a/crates/flux-driver/src/callbacks.rs
+++ b/crates/flux-driver/src/callbacks.rs
@@ -16,7 +16,7 @@ use flux_middle::{
     queries::{Providers, QueryResult},
     timings,
 };
-use flux_opt as flux_opt;
+use flux_opt::{self as flux_opt, entry_point, run_mir_analysis_on_all_functions};
 use flux_refineck as refineck;
 use itertools::Itertools;
 use rustc_borrowck::consumers::ConsumerOptions;
@@ -79,11 +79,12 @@ impl FluxCallbacks {
             if result.is_ok() {
                 encode_and_save_metadata(genv);
             }
+
+            run_mir_analysis_on_all_functions(genv);
         });
+
         sess.finish_diagnostics();
 
-        // Call flux_opt entry point
-        flux_opt::entry_point();
     }
 }
 

--- a/crates/flux-opt/Cargo.toml
+++ b/crates/flux-opt/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "flux-opt"
+version = "0.1.0"
+
+edition.workspace = true
+
+[lib]
+doctest = false
+test = false
+
+[dependencies]
+flux-macros.workspace = true
+flux-config.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true
+
+[lints]
+workspace = true

--- a/crates/flux-opt/Cargo.toml
+++ b/crates/flux-opt/Cargo.toml
@@ -11,6 +11,7 @@ test = false
 [dependencies]
 flux-macros.workspace = true
 flux-config.workspace = true
+flux-middle.workspace = true
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/crates/flux-opt/src/hint.rs
+++ b/crates/flux-opt/src/hint.rs
@@ -1,0 +1,16 @@
+use rustc_span::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FluxPanicType {
+    BoundsCheck,
+    DivisionByZero,
+    RemainderByZero,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FluxHint {
+    pub function: String,
+    pub span: Span,
+    pub assertion: String,
+    pub panic_type: FluxPanicType,
+}

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -1,0 +1,3 @@
+pub fn entry_point() {
+    panic!("This is the entry point of the flux-opt crate.");
+}

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -10,10 +10,28 @@ use rustc_hir::{
 };
 use rustc_middle::mir::pretty::write_mir_pretty;
 
+/// These are the ring buffer functions that we actually
+/// care about.
+const EXPECTED_FUNCTIONS: &[&str] = &[
+    "available_len",
+    "as_slices",
+    "has_elements",
+    "is_full",
+    "len",
+    "enqueue",
+    "push",
+    "dequeue",
+    "remove_first_matching",
+    "empty",
+    "retain",
+];
+
 // 🎯 NEW: Helper function to run MIR analysis on all functions
 pub fn run_mir_analysis_on_all_functions(genv: GlobalEnv) {
     let tcx = genv.tcx();
     let crate_items = tcx.hir_crate_items(());
+
+    let mut total_panics = 0;
     
     // Iterate through all items in the crate
     for def_id in crate_items.definitions() {
@@ -21,31 +39,46 @@ pub fn run_mir_analysis_on_all_functions(genv: GlobalEnv) {
         // Check if this item is a function
         match tcx.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {
-                println!("🔍 Analyzing function: {}", tcx.def_path_str(def_id));
-                
-                // Call your entry_point for this specific function
-                entry_point(tcx, def_id);
+                let def_path = tcx.def_path_str(def_id);
+                let fn_name = parse_fn_name(&def_path);
+                if EXPECTED_FUNCTIONS.contains(&fn_name) {
+                    // Call your entry_point for this specific function
+                    total_panics += entry_point(tcx, def_id);
+                }
             }
             _ => {
                 // Skip non-function items (structs, enums, etc.)
             }
         }
     }
+
+    if total_panics > 0 {
+        eprintln!("=== FLUX-OPT: Total panics found across all functions: {} ===", total_panics);
+    }
 }
 
-pub fn entry_point(tcx: TyCtxt<'_>, def_id: LocalDefId) {
-    println!("=== FLUX-OPT: Starting MIR analysis ===");
+fn parse_fn_name(fn_name: &str) -> &str {
+    // Find the last occurrence of "::" and return the substring after it
+    if let Some(pos) = fn_name.rfind("::") {
+        &fn_name[pos + 2..]
+    } else {
+        fn_name
+    }
+}
 
+pub fn entry_point(tcx: TyCtxt<'_>, def_id: LocalDefId) -> usize {
     let fn_name = tcx.def_path_str(def_id.to_def_id());
+    println!("🔎 Starting analysis of {}", fn_name);
 
-       // 🎯 FIX: Check if this definition has a body before accessing MIR
+    // 🎯 FIX: Check if this definition has a body before accessing MIR
     if !tcx.is_mir_available(def_id.to_def_id()) {
         println!("⚠️  Skipping {}: No MIR available (likely a trait method declaration)", fn_name);
-        return;
+        return 0;
     }
 
+    let mut panics = 0;
+
     for basic_block in tcx.optimized_mir(def_id.to_def_id()).basic_blocks.iter() {
-        println!("Function: {}, Basic Block: {:?}", fn_name, basic_block);
         let terminator = &basic_block.terminator;
         if terminator.is_none() {
             continue;
@@ -54,11 +87,11 @@ pub fn entry_point(tcx: TyCtxt<'_>, def_id: LocalDefId) {
         match &terminator.kind {
             TerminatorKind::Assert { cond, expected, msg, target, .. } => {
                 // Print to stderr
+                panics += 1;
                 eprintln!("Inside function: {}, Found an assert saying {:?}", fn_name, msg);
             }
             _ => {}
         }
     }
-
-    println!("=== FLUX-OPT: Finished MIR analysis ===");
+    panics
 }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -20,6 +20,9 @@ pub mod hint;
 
 pub type HintsPerModule = HashMap<String, Vec<FluxHint>>;
 
+pub const ROOT_ID: &str = "<root>";
+
+
 /// Gathers and prints to stderr all panic hints found in the crate.
 /// See [`FluxHint`] for details on the hints collected.
 pub fn gather_crate_panics(tcx: TyCtxt<'_>) -> Result<HintsPerModule, String> {
@@ -35,7 +38,7 @@ pub fn gather_crate_panics(tcx: TyCtxt<'_>) -> Result<HintsPerModule, String> {
                 let module_path = def_path
                     .rsplit_once("::")
                     .map(|(module, _)| module)
-                    .unwrap_or("<root>")
+                    .unwrap_or(ROOT_ID)
                     .to_string();
 
                 let hints = get_hints_for_func(tcx, def_id);

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -191,10 +191,10 @@ fn prettify_local_one_block<'tcx>(
                     // We're not doing anything with raw pointers.
                     prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body)
                 }
-                Rvalue::Use(arg) => Ok(prettify_operand_one_block(tcx, &arg, block, body)?),
-                _ => {
-                    todo!("I don't know what to do with a {:?}!", rvalue);
-                }
+                _ => return Err(format!(
+                    "I don't know what to do with a {:?}!",
+                    rvalue
+                )),
             }
         }
         None => Err(format!("No assignment found for local _{} in the given block", local.index())),

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -5,7 +5,6 @@ extern crate rustc_span;
 
 use std::collections::HashMap;
 
-use flux_middle::global_env::GlobalEnv;
 use rustc_hir::{def::DefKind, def_id::LocalDefId};
 use rustc_middle::{
     mir::{
@@ -17,12 +16,11 @@ use rustc_middle::{
 
 use crate::hint::FluxHint;
 
-mod hint;
+pub mod hint;
 
 /// Gathers and prints to stderr all panic hints found in the crate.
 /// See [`FluxHint`] for details on the hints collected.
-pub fn gather_crate_panics(genv: GlobalEnv) {
-    let tcx = genv.tcx();
+pub fn gather_crate_panics(tcx: TyCtxt<'_>) {
     let crate_items = tcx.hir_crate_items(());
     let mut panics_per_module: HashMap<String, Vec<FluxHint>> = HashMap::new();
 

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -5,6 +5,7 @@ extern crate rustc_span;
 
 use std::collections::HashMap;
 
+use flux_middle::fhir::Ty;
 use rustc_hir::{def::DefKind, def_id::LocalDefId};
 use rustc_middle::{
     mir::{
@@ -18,11 +19,13 @@ use crate::hint::FluxHint;
 
 pub mod hint;
 
+pub type HintsPerModule = HashMap<String, Vec<FluxHint>>;
+
 /// Gathers and prints to stderr all panic hints found in the crate.
 /// See [`FluxHint`] for details on the hints collected.
-pub fn gather_crate_panics(tcx: TyCtxt<'_>) {
+pub fn gather_crate_panics(tcx: TyCtxt<'_>) -> Result<HintsPerModule, String> {
     let crate_items = tcx.hir_crate_items(());
-    let mut panics_per_module: HashMap<String, Vec<FluxHint>> = HashMap::new();
+    let mut result: HashMap<String, Vec<FluxHint>> = HashMap::new();
 
     // 1. Iterate through all items in the crate
     for def_id in crate_items.definitions() {
@@ -31,16 +34,13 @@ pub fn gather_crate_panics(tcx: TyCtxt<'_>) {
         match tcx.def_kind(def_id) {
             DefKind::Fn | DefKind::AssocFn => {
                 let module_path = def_path
-                    .rsplit_once("::") 
+                    .rsplit_once("::")
                     .map(|(module, _)| module)
                     .unwrap_or("<root>")
                     .to_string();
 
                 let hints = get_hints_for_func(tcx, def_id);
-                panics_per_module
-                    .entry(module_path)
-                    .or_default()
-                    .extend(hints);
+                result.entry(module_path).or_default().extend(hints);
             }
             _ => {
                 // Skip non-function items (structs, enums, etc.)
@@ -48,8 +48,8 @@ pub fn gather_crate_panics(tcx: TyCtxt<'_>) {
         }
     }
 
-    for module in panics_per_module.keys() {
-        let hints = &panics_per_module[module];
+    for module in result.keys() {
+        let hints = &result[module];
         eprintln!("=== FLUX-OPT: Panics found in module '{}': {} ===", module, hints.len());
         for hint in hints {
             eprintln!(
@@ -58,59 +58,65 @@ pub fn gather_crate_panics(tcx: TyCtxt<'_>) {
             );
         }
     }
+
+    Ok(result)
 }
 
 fn prettify_operand_one_block<'tcx>(
     tcx: TyCtxt<'tcx>,
     op: &Operand<'tcx>,
-    block: &BasicBlockData<'tcx>,
+    block: &'tcx BasicBlockData<'tcx>,
     body: &Body<'tcx>,
-) -> String {
+) -> Result<String, String> {
     match op {
         Operand::Copy(place) | Operand::Move(place) => {
-            let obj = prettify_local_one_block(tcx, place.local, block, body)
-                .unwrap_or(format!("_{}", place.local.index()));
-            // try to get fields
-            let arg = place;
+            let obj = prettify_local_one_block(tcx, place.local, block, body)?;
 
-            if arg.projection.is_empty() || arg.projection.len() < 2 {
-                return obj;
-            }
-
-            // match on one dereference and one field access
-            // For field access like `self._0`, you want the type of `self` (the base)
-            if let ProjectionElem::Field(field_idx, _) = &arg.projection[1] {
-                // Get the type of the place BEFORE the field projection
-                let base_place = Place {
-                    local: place.local,
-                    projection: tcx.mk_place_elems(&place.projection[..place.projection.len() - 1]),
-                };
-
-                // This gives you the type of `self` (the parent/base type)
-                let base_ty = base_place.ty(&body.local_decls, tcx).ty;
-
-                // Now you can get the ADT definition to look up field names
-                if let Some(adt_def) = base_ty.ty_adt_def() {
-                    // Fixed syntax
-                    if let Some(field_def) = adt_def.all_fields().nth(field_idx.as_usize()) {
-                        let field_name = field_def.name.as_str();
-                        return format!("{}.{}", obj, field_name);
-                    }
-                }
-
-                // Fallback if we can't get the field name
-                return format!("{}._{}", obj, field_idx.index());
-            }
-
-            obj
+            return Ok(prettify_projections(tcx, obj, place, body)?);
         }
         Operand::Constant(c) => {
             if let Some(scalar_int) = c.const_.try_to_scalar_int() {
-                return format!("{}", scalar_int);
+                return Ok(format!("{}", scalar_int));
             }
-            format!("{:?}", c)
+            return Err(format!("I don't know how to prettify this constant: {:?}", c));
         }
     }
+}
+
+// TODO(@ninehusky): test this.
+fn prettify_projections<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    base: String,
+    place: &Place<'tcx>,
+    body: &Body<'tcx>,
+) -> Result<String, String> {
+    let mut result = base;
+
+    for (base, proj) in place.iter_projections() {
+        match proj {
+            ProjectionElem::Deref => {
+                result = format!("*{}", result);
+            }
+            ProjectionElem::Field(field_idx, _) => {
+                let base_ty = base.ty(&body.local_decls, tcx);
+                match base_ty.ty.ty_adt_def() {
+                    Some(adt_def) => {
+                        if let Some(field_def) = adt_def.all_fields().nth(field_idx.as_usize()) {
+                            let field_name = field_def.name.as_str();
+                            result = format!("{}.{}", result, field_name);
+                            continue;
+                        }
+                    }
+                    None => return Err(format!("Base type is not an ADT: {:?}", base_ty)),
+                };
+            }
+            _ => {
+                return Err(format!("Unsupported projection element: {:?}", proj));
+            }
+        }
+    }
+
+    Ok(result)
 }
 
 /// Pretty-print the value of a local within a single basic block.
@@ -118,15 +124,15 @@ fn prettify_operand_one_block<'tcx>(
 fn prettify_local_one_block<'tcx>(
     tcx: TyCtxt<'tcx>,
     local: Local,
-    block: &BasicBlockData<'tcx>,
+    block: &'tcx BasicBlockData<'tcx>,
     body: &Body<'tcx>,
-) -> Option<String> {
+) -> Result<String, String> {
     // Check if the local is a debug variable
     if let Some(name) = debug_name_for_local(body, local) {
-        return Some(name);
+        return Ok(name);
     }
 
-    let og_assignment = find_assignment(block, local);
+    let og_assignment: Option<(&'tcx Place<'tcx>, &'tcx Rvalue<'tcx>)> = find_assignment(block, local);
     match og_assignment {
         Some((_, rvalue)) => {
             match rvalue {
@@ -136,23 +142,21 @@ fn prettify_local_one_block<'tcx>(
                         BinOp::Lt => "<",
                         BinOp::Le => "<=",
                         _ => {
-                            eprintln!("Unsupported binary operation: {:?}", op);
-                            return None;
-                        },
+                            return Err(format!("Unsupported binary operation: {:?}", op));
+                        }
                     };
-                    let left = prettify_operand_one_block(tcx, &args.0, block, body);
-                    let right = prettify_operand_one_block(tcx, &args.1, block, body);
-                    Some(format!("{} {} {}", left, op_str, right))
+                    let left = prettify_operand_one_block(tcx, &args.0, block, body)?;
+                    let right = prettify_operand_one_block(tcx, &args.1, block, body)?;
+                    Ok(format!("{} {} {}", left, op_str, right))
                 }
                 // NOTE(@ninehusky): This is suspicious.
-                // I chatted with Vivien about this and this seems right?
+                // I chatted with Vivien/Evan about this and this seems right?
                 // Basically, there is a difference between a Rvalue::Len and a
                 // UnOp::PtrMetdata called with a slice/array, even though
                 // it seems that both of them do the same thing.
                 // In our current implementation, we _only_ support
                 // UnOp::PtrMetadata for getting lengths of slices/arrays.
                 Rvalue::UnaryOp(op, arg) => {
-                    eprintln!("unary op {:?} on arg projection: {:?}", op, arg.place().unwrap().projection);
                     let op_str = {
                         match op {
                             UnOp::PtrMetadata => {
@@ -162,79 +166,52 @@ fn prettify_local_one_block<'tcx>(
                                 if arg_type.is_array_slice() || arg_type.is_slice() {
                                     "len"
                                 } else {
-                                    todo!()
+                                    return Err("PtrMetadata applied to non-slice type".to_string());
                                 }
                             }
-                            _ => todo!(),
+                            _ => return Err(format!("Unsupported unary operation: {:?}", op)),
                         }
                     };
-                    let inner = prettify_operand_one_block(tcx, &arg, block, body);
-                    Some(format!("{}.{}()", inner, op_str))
+                    // The expectation is that if we are here, the op_str is "len".
+                    assert_eq!(op_str, "len");
+                    let inner = prettify_operand_one_block(tcx, &arg, block, body)?;
+                    Ok(format!("{}.{}()", inner, op_str))
                 }
                 Rvalue::CopyForDeref(arg) => {
-                    let obj =
-                        prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body);
-                    Some(format!("&{}", obj))
+                    let obj = prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body)?;
+                    Ok(format!("&{}", obj))
                 }
                 Rvalue::Ref(_, _, arg) => {
-                    let obj =
-                        prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body);
-                    if arg
-                        .projection
-                        .iter()
-                        .any(|elem| matches!(elem, ProjectionElem::Field(_, _)))
-                    {
-                        let field = arg.projection.iter().find_map(|elem| {
-                            if let ProjectionElem::Field(field_idx, _) = elem {
-                                Some(field_idx)
-                            } else {
-                                None
-                            }
-                        });
-                        if let Some(field_idx) = field {
-                            let base_ty = arg.ty(&body.local_decls, tcx).ty;
-                            // This gives you the type of `self` (the parent/base type)
-                            if let Some(adt_def) = base_ty.ty_adt_def() {
-                                if let Some(field_def) = 
-                                    adt_def.all_fields().nth(field_idx.as_usize())
-                                {
-                                    let field_name = field_def.name.as_str();
-                                    return Some(format!("{}.{}", obj, field_name));
-                                }
-                            }
-                            Some(obj)
-                        } else {
-                            Some(obj)
-                        }
-                    } else {
-                        Some(obj)
-                    }
+                    let base =
+                        prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body)?;
+                    prettify_projections(tcx, base, arg, body)
                 }
-                Rvalue::RawPtr(_, arg) => {
+                Rvalue::RawPtr(kind, arg) => {
+                    let ptr_str = kind.ptr_str();
                     let obj =
-                        prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body);
-                    Some(format!("{}", obj))
+                        prettify_operand_one_block(tcx, &Operand::Copy(arg.clone()), block, body)?;
+                    Ok(format!("{}{}", ptr_str, obj))
                 }
-                Rvalue::Use(arg) => Some(prettify_operand_one_block(tcx, &arg, block, body)),
+                Rvalue::Use(arg) => Ok(prettify_operand_one_block(tcx, &arg, block, body)?),
                 _ => {
                     todo!("I don't know what to do with a {:?}!", rvalue);
                 }
             }
         }
-        None => None,
+        None => Err(format!("No assignment found for local _{} in the given block", local.index())),
     }
 }
 
 fn find_assignment<'tcx>(
-    block_data: &BasicBlockData<'tcx>,
+    block_data: &'tcx BasicBlockData<'tcx>,
     target: Local,
-) -> Option<(Place<'tcx>, Rvalue<'tcx>)> {
+) -> Option<(&'tcx Place<'tcx>, &'tcx Rvalue<'tcx>)> {
     for statement in block_data.statements.iter().rev() {
         if let StatementKind::Assign(vals) = &statement.kind {
             let place = &vals.0;
             let rvalue = &vals.1;
             if place.local == target {
-                return Some((place.clone(), rvalue.clone()));
+                return Some((place, rvalue));
             }
         }
     }
@@ -277,7 +254,9 @@ pub fn get_hints_for_func(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Vec<FluxHint> 
         match &terminator.kind {
             TerminatorKind::Assert { cond, msg, .. } => {
                 match &**msg {
-                    AssertKind::BoundsCheck { .. } => {
+                    AssertKind::BoundsCheck { .. }
+                    | AssertKind::DivisionByZero(_)
+                    | AssertKind::RemainderByZero(_) => {
                         if let Operand::Copy(place) | Operand::Move(place) = cond {
                             let local = place.local;
                             let debug_msg = prettify_local_one_block(
@@ -287,38 +266,30 @@ pub fn get_hints_for_func(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Vec<FluxHint> 
                                 &tcx.optimized_mir(def_id.to_def_id()),
                             );
 
-                            if let Some(assertion_str) = debug_msg.clone() {
+                            let panic_type = match &**msg {
+                                AssertKind::BoundsCheck { .. } => hint::FluxPanicType::BoundsCheck,
+                                AssertKind::DivisionByZero(_) => {
+                                    hint::FluxPanicType::DivisionByZero
+                                }
+                                AssertKind::RemainderByZero(_) => {
+                                    hint::FluxPanicType::RemainderByZero
+                                }
+                                _ => unreachable!(),
+                            };
+
+                            if let Ok(assertion_str) = debug_msg.clone() {
                                 let hint = FluxHint {
                                     span: terminator.source_info.span,
                                     assertion: assertion_str,
-                                    panic_type: hint::FluxPanicType::BoundsCheck,
+                                    panic_type,
                                     function: parse_fn_name(&fn_name).to_string(),
                                 };
                                 panics.push(hint);
-                            }
-                        }
-                    }
-                    AssertKind::RemainderByZero(_) | AssertKind::DivisionByZero(_) => {
-                        if let Operand::Copy(place) | Operand::Move(place) = cond {
-                            let local = place.local;
-                            let debug_msg = prettify_local_one_block(
-                                tcx,
-                                local,
-                                basic_block,
-                                &tcx.optimized_mir(def_id.to_def_id()),
-                            );
-                            if let Some(assertion_str) = debug_msg.clone() {
-                                let hint = FluxHint {
-                                    span: terminator.source_info.span,
-                                    assertion: assertion_str,
-                                    panic_type: if matches!(**msg, AssertKind::DivisionByZero(_)) {
-                                        hint::FluxPanicType::DivisionByZero
-                                    } else {
-                                        hint::FluxPanicType::RemainderByZero
-                                    },
-                                    function: parse_fn_name(&fn_name).to_string(),
-                                };
-                                panics.push(hint);
+                            } else {
+                                eprintln!(
+                                    "Couldn't resolve debug message {:?} for bounds check in function {}",
+                                    debug_msg, fn_name
+                                );
                             }
                         }
                     }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -1,3 +1,59 @@
-pub fn entry_point() {
-    panic!("This is the entry point of the flux-opt crate.");
+#![feature(rustc_private)]
+extern crate rustc_middle;
+extern crate rustc_hir;
+
+use flux_middle::global_env::GlobalEnv;
+use rustc_middle::{ty::TyCtxt};
+use rustc_hir::{
+    def::DefKind,
+    def_id::{DefId, LOCAL_CRATE, LocalDefId},
+};
+use rustc_middle::mir::pretty::write_mir_pretty;
+
+// 🎯 NEW: Helper function to run MIR analysis on all functions
+pub fn run_mir_analysis_on_all_functions(genv: GlobalEnv) {
+    let tcx = genv.tcx();
+    let crate_items = tcx.hir_crate_items(());
+    
+    // Iterate through all items in the crate
+    for def_id in crate_items.definitions() {
+        
+        // Check if this item is a function
+        match tcx.def_kind(def_id) {
+            DefKind::Fn | DefKind::AssocFn => {
+                println!("🔍 Analyzing function: {}", tcx.def_path_str(def_id));
+                
+                // Call your entry_point for this specific function
+                entry_point(tcx, def_id);
+            }
+            _ => {
+                // Skip non-function items (structs, enums, etc.)
+            }
+        }
+    }
+}
+
+pub fn entry_point(tcx: TyCtxt<'_>, def_id: LocalDefId) {
+    println!("=== FLUX-OPT: Starting MIR analysis ===");
+
+    let fn_name = tcx.def_path_str(def_id.to_def_id());
+
+    // get optimized MIR (this triggers pipeline if needed)
+    let mir = tcx.optimized_mir(def_id.to_def_id());
+    // write pretty MIR to stdout (or a file)
+    if let Err(e) = write_mir_pretty(tcx, Some(def_id.to_def_id()), &mut std::io::stdout()) {
+        // fallback to debug
+        eprintln!("write_mir_pretty failed: {:?}\nDumping Debug:", e);
+        println!("{:#?}", &*mir);
+    } else {
+        let err_file = format!("mir_{}.txt", fn_name.replace("::", "_"));
+        let mut file = std::fs::File::create(&err_file).expect("Could not create MIR output file");
+        let absolute_path = std::fs::canonicalize(&err_file).expect("Could not get absolute path");
+        write_mir_pretty(tcx, Some(def_id.to_def_id()), &mut file).unwrap();
+        panic!("MIR for function '{}' written to {}", fn_name, absolute_path.display());
+
+
+    }
+    
+    println!("=== FLUX-OPT: Finished MIR analysis ===");
 }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -200,7 +200,7 @@ fn prettify_local_one_block<'tcx>(
                                 }
                             }
                             // TODO(@ninehusky): remove this debug string
-                            Some(format!("{}.copyfor...{:?}", obj, field_idx))
+                            Some(obj)
                         } else {
                             Some(obj)
                         }

--- a/crates/flux-opt/src/lib.rs
+++ b/crates/flux-opt/src/lib.rs
@@ -136,7 +136,10 @@ fn prettify_local_one_block<'tcx>(
                         BinOp::Eq => "==",
                         BinOp::Lt => "<",
                         BinOp::Le => "<=",
-                        _ => todo!("I have no idea how to format a {:?}", op),
+                        _ => {
+                            eprintln!("Unsupported binary operation: {:?}", op);
+                            return None;
+                        },
                     };
                     let left = prettify_operand_one_block(tcx, &args.0, block, body);
                     let right = prettify_operand_one_block(tcx, &args.1, block, body);

--- a/crates/flux-opt/tests/hints.rs
+++ b/crates/flux-opt/tests/hints.rs
@@ -1,0 +1,127 @@
+#![feature(rustc_private)]
+
+extern crate rustc_interface;
+extern crate rustc_middle;
+extern crate rustc_session;
+extern crate rustc_span;
+
+// We need this to run tests for some reason.
+extern crate rustc_driver;
+
+use core::panic;
+use std::sync::atomic::AtomicBool;
+
+use flux_middle::{fhir, global_env::GlobalEnv, queries::Providers, timings, Specs};
+use flux_opt::{gather_crate_panics, hint::FluxHint};
+use rustc_driver::Callbacks;
+use rustc_interface::Config;
+use rustc_session::config::Options;
+
+pub struct DummyCallback {
+    pub expected: Vec<FluxHint>,
+}
+
+impl Callbacks for DummyCallback {
+    fn config(&mut self, _config: &mut rustc_interface::interface::Config) {
+        // we're not gonna do anything.
+    }
+
+    fn after_analysis<'tcx>(
+            &mut self,
+            compiler: &rustc_interface::interface::Compiler,
+            tcx: rustc_middle::ty::TyCtxt<'tcx>,
+        ) -> rustc_driver::Compilation {
+            if compiler.sess.dcx().has_errors().is_some() {
+                panic!("Compilation error!");
+            }
+            let res = gather_crate_panics(tcx);
+            match res {
+                Ok(hints) => {
+                    assert_eq!(hints, self.expected);
+                }
+                Err(e) => {
+                    panic!("Error gathering panics: {:?}", e);
+                }
+            }
+            rustc_driver::Compilation::Stop
+    }
+
+}
+
+// A helper function to run our Flux-Opt algorithm on a source string.
+fn run_mii(src: &'static str) -> GlobalEnv {
+    // 1. Create an Input from the source string.
+    let input = rustc_session::config::Input::Str {
+        name: rustc_span::FileName::anon_source_code(src),
+        input: src.to_string(),
+    };
+
+    // 2. Define a config. I kind of just set everything to
+    // "None" or the equivalent default value.
+    let config = Config {
+        opts: Options::default(),
+        crate_cfg: Default::default(),
+        crate_check_cfg: Default::default(),
+        input,
+        output_dir: None,
+        output_file: None,
+        file_loader: None,
+        lint_caps: Default::default(),
+        register_lints: None,
+        override_queries: None,
+        make_codegen_backend: None,
+        registry: rustc_driver::diagnostics_registry(),
+        ice_file: None,
+        locale_resources: vec![],
+        psess_created: None,
+        hash_untracked_state: None,
+        extra_symbols: vec![],
+        using_internal_features: &AtomicBool::new(false),
+        expanded_args: vec![], 
+    };
+
+    // 3. Run the compiler with the config.
+
+    let mut result: Vec<FluxHint> = vec![];
+    rustc_driver::run_compiler(config, |compiler| {
+        if compiler.sess.dcx().has_errors().is_some() {
+            panic!("Compilation error!");
+        }
+
+        compiler.enter(|tcx| {
+            // 4. Create a GlobalEnv from the TyCtxt.
+            let genv = GlobalEnv::new(tcx);
+
+            // 5. Run Flux-Opt on the GlobalEnv to get hints.
+            result = flux_opt::hint_generation::generate_hints(&genv);
+        });
+    });
+}
+
+pub mod hint_tests {
+    use flux_opt::hint::{FluxHint, FluxPanicType};
+
+    #[test]
+    fn test_flux_hint_creation() {
+        let hint = FluxHint {
+            function: "test_function".to_string(),
+            span: rustc_span::DUMMY_SP,
+            assertion: "i < len".to_string(),
+            panic_type: FluxPanicType::BoundsCheck,
+        };
+        assert_eq!(hint.function, "test_function");
+        assert_eq!(hint.assertion, "i < len");
+        assert_eq!(hint.panic_type, FluxPanicType::BoundsCheck);
+    }
+
+    #[test]
+    fn get_mir() {
+        let rust_src = r#"
+        fn divide(a: i32, b: i32) -> i32 {
+            a / b
+        }
+        "#;
+
+        let mir = flux_opt::tests::get_mir_from_source(rust_src, "divide");
+    }
+}


### PR DESCRIPTION
Closes #1.

Here is the roadmap:
- [x] add dummy MIR pass included as `flux-opt` crate within flux
- [x] find each `assert` within expected basic blocks (not all)
- [x] decompile conditions of `assert`s back up to HIR (give up if we can't find a debug variable)
- ~~[ ] include dummy folder here for ease of testing? this should include panics for div by zero, rem zero, bounds checks.~~
- ~~[ ] output json for type of panic --> num occurrences~~